### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,4 +28,4 @@ print(score)
 
 
 
-# Note : You can use polarity_scores_max instead of polarity_scores. polarity_scores_max uses fuzzywuzzy to get the most similar words with your inputs. For example "connar" won't be detected with polarity_scores but with polarity_scores_max
+# Note : You can use polarity_scores_max instead of polarity_scores. polarity_scores_max uses rapidfuzz to get the most similar words with your inputs. For example "connar" won't be detected with polarity_scores but with polarity_scores_max

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
   keywords = ['Vader_FR', 'vaderSentiment', 'Vader','Sentiment','French','Analysis'],   # Keywords that define your package best
   install_requires=[            # I get to this in a second
           'unidecode',
-          'fuzzywuzzy'
+          'rapidfuzz'
       ],
   classifiers=[
     'Development Status :: 3 - Alpha',      # Chose either "3 - Alpha", "4 - Beta" or "5 - Production/Stable" as the current state of your package

--- a/vaderSentiment_fr.egg-info/PKG-INFO
+++ b/vaderSentiment_fr.egg-info/PKG-INFO
@@ -37,7 +37,7 @@ Description: ====================================
         
         
         
-        # Note : You can use polarity_scores_max instead of polarity_scores. polarity_scores_max uses fuzzywuzzy to get the most similar words with your inputs. For example "connar" won't be detected with polarity_scores but with polarity_scores_max
+        # Note : You can use polarity_scores_max instead of polarity_scores. polarity_scores_max uses rapidfuzz to get the most similar words with your inputs. For example "connar" won't be detected with polarity_scores but with polarity_scores_max
         
 Keywords: Vader_FR,vaderSentiment,Vader,Sentiment,French,Analysis
 Platform: UNKNOWN

--- a/vaderSentiment_fr.egg-info/requires.txt
+++ b/vaderSentiment_fr.egg-info/requires.txt
@@ -1,2 +1,2 @@
 unidecode
-fuzzywuzzy
+rapidfuzz

--- a/vaderSentiment_fr/vaderSentiment.py
+++ b/vaderSentiment_fr/vaderSentiment.py
@@ -21,12 +21,12 @@ import unidecode
 from itertools import product
 from inspect import getsourcefile
 from io import open
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 import time
 import vaderSentiment_fr.tree as tree
 
 # ##Constants##
-# nombre minimum de lettres à vérifier pour fuzzywuzzy
+# nombre minimum de lettres à vérifier pour rapidfuzz
 nb_lettres_min=3
 
 
@@ -230,7 +230,7 @@ class SentimentIntensityAnalyzer(object):
         max_ratio = 0
         for word, polarity in self.lexicon.items():
             word = unidecode.unidecode(word)
-            ratio = fuzz.ratio(word, item)
+            ratio = fuzz.ratio(word, item, score_cutoff=max_ratio)
             if ratio > max_ratio:
                 max_ratio = ratio
                 max_word = word


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy